### PR TITLE
IN-234 Initial version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: cimg/go:1.15
+    steps:
+      - checkout
+      - run:
+          name: Test Make Recipes
+          command: |
+            make test
+
+workflows:
+  version: 2
+  "Simple Tests":
+    jobs:
+      - test:
+          filters:
+            branches:
+              only: /.*/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+TESTS=$(wildcard test/test[0-9]*)
+
+# Simple set of tests
+test:
+	$(foreach TEST,$(TESTS),(cd $(TEST) && sh ../test.sh || kill $$$$) ;)
+
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,208 @@
-# common-make
-Common Make infrastructure for ANet Engineering
+# Common Make
+
+This repo contains common Make recipes for use at ANet.  These recipes should be used
+in preference to each repo repeating similar code in its Makefile.
+
+Recipe categories currently include:
+
+* Go
+* Copy
+
+## Go
+
+Recipes for building, testing and checking Go executables are included in `go-common.mk`
+
+### Targets
+
+The primary targets provided for Go are:
+
+* __build__ - Builds Go executables
+* __clean__ - Removes build targets
+* __lint__ - Lints Go source
+* __test__ - Runs Go unit tests
+* __testcover__ - Runs Go unit tests and produces code coverage data
+
+Each primary target depends on three sub-targets, which use the prefixes `pre-`,
+`standard-`, and `post-`.  E.g., the sub-targets for the `build` target are
+`pre-build`, `standard-build`, and `post-build`.  The common recipes only define
+actions for `standard-` sub-target.  The others are provided to allow custom actions.
+
+### Variables
+
+These variables are used by the standard targets and may be overridden:
+
+* __PROJECT__ - The name of the project being built.  Defaults to the name of the current directory (which should be also the name of the repository)
+* __BUILDDIR__ - The location that build artifacts will be placed in.  Defaults to `./build`
+* __GOTARGETS__ - A list of the executables to build.  Defaults to the project name
+* __GOCMDDIR__ - The location of the directory containing the sub-directories for the executables to be built.  Defaults to `./cmd`
+* __GOROOTTARGET__ - Can be set to the name of a single target from `GOTARGETS` if the main executable code for it is in the top level directory.  No default
+* __GOSRC__ - A list of the Go source files.  Defaults to all Go source files recursively found in the current directory
+* __GO__ - The Go executable to run.  Defaults to `go`
+* __GOFLAGS__ - Flags to pass to `go build`.  No default
+* __GOTESTTARGET__ - The target to pass to `go test`.  Defaults to `./...`, which means all tests in the project
+* __GOTESTFLAGS__ - Flags to pass to `go test`.  Defaults to `-v -race`
+
+
+## Copy
+
+Recipes for copying files as part of the build are included in `copy-common.mk`
+
+### Targets
+
+The primary targets provided for Go are:
+
+* __build__ - Copies files into the build directory
+* __clean__ - Removes build targets
+
+Each primary target depends on three sub-targets, which use the prefixes `pre-`,
+`standard-`, and `post-`.  E.g., the sub-targets for the `build` target are
+`pre-build`, `standard-build`, and `post-build`.  The common recipes only define
+actions for `standard-` sub-target.  The others are provided to allow custom actions.
+
+### Variables
+
+These variables are used by the standard targets and may be overridden:
+
+* __PROJECT__ - The name of the project being built.  Defaults to the name of the current directory (which should be also the name of the repository)
+* __BUILDDIR__ - The location that build artifacts will be placed in.  Defaults to `./build`
+* __COPY__ - The program to use to copy files.  Defaults to `cp`
+* __COPYTARGETS__ - A list of files and directories to be copied into `BUILDDIR`.  No default
+* __COPYFLAGS__ - Flags to pass to `COPY`.  Defaults to `-r`
+
+## Using
+
+The normal way to use the common make recipes is to include the appropriate files in
+the Makefile for a repository.  For a simple Go microservice, just including
+`go-common.mk` may be all that is required in the Makefile, for example:
+
+```make
+include go-common.mk
+```
+
+### Include
+
+In all cases the Makefile will ultimately reference one or more of the `*-common.mk`
+files in this package, usually through the use of the `include` directive.  However,
+there are a number of options on how this directive can be resolved.
+
+#### Dynamic download
+
+In this option, the Makefile includes a target for creating the common make file that
+is included by downloading it from Github as well as an `include` directive.  In this
+case the name of the common make file that is downloaded should be added to
+`.gitignore` for the package so that it is not inadvertently committed.
+
+`curl` will be used in the following examples to illustrate a variety of forms this
+could take.
+
+Get the most recent version of `go-common-mk`:
+
+```make
+include go-common.mk
+
+go-common.mk:
+	curl -O -L https://raw.github.com/AchievementNetwork/common-make/master/go-common.mk
+```
+
+Get the version for a specific release:
+
+```make
+include go-common.mk
+
+go-common.mk:
+	curl -O -L https://raw.github.com/AchievementNetwork/common-make/1.0.0/go-common.mk
+```
+
+Get the version for a specific commit:
+
+```make
+include go-common.mk
+
+go-common.mk:
+	curl -O -L https://raw.github.com/AchievementNetwork/common-make/<commit-hash>/go-common.mk
+```
+
+__Pros__
+
+* New common make features will be pulled in automatically as they are added (although see the caveat in the __Cons__ section)
+* Depending on the download recipe used, package maintainers have flexibility in whether they will automatically pick up none, some, or all updates
+
+__Cons__
+
+* All users, including the package builder, must have network access in order to build the package, at least initially
+* Developers may need to periodically to refresh the common make files if another developer starts using the features of a newer version
+
+#### Local copy
+
+In this option, a copy of the appropriate `*-common.mk` file(s) are downloaded manually and
+checked into the package being built.  In this case the Makefile can just use the
+`include` directive with no additional complications.
+
+__Pros__
+
+* The Makefile only needs a simple include statement
+* The package is self-contained and fully in control of pulling in future common make infrastructure updates
+
+__Cons__
+
+* Developers may make local changes to the common make infrastructure which are not fed upstream, making future updates painful or even infeasible in the worst cases
+* The package will not pick up any common make updates without manual intervention
+
+
+### Overriding variables
+
+Overriding variables should be done before referencing the common make recipes.  E.g., to
+override `GOFLAGS` so that package names are printed as they are compiled your
+`Makefile` might look like
+
+```make
+GOFLAGS=-v
+
+include go-common.mk
+```
+
+### Adding to targets
+
+All public targets in the common make recipes are so-called double colon targets.  This
+means that additional targets with the same name can be defined and they will be run in
+addition to the common make targets.
+
+These additional targets must also be double colon targets, since Make does not allow a
+target to have both single and double colon versions.
+
+As trivial example, to print a message that the main build step was about to start your
+`Makefile` might look like this:
+
+```make
+pre-build::
+	@echo "Main build about to start"
+
+include go-common.mk
+```
+
+Note that the `pre-` and `post-` targets are all designed to specifically allow for
+this and are empty in the common make infrastructure.
+
+### Overriding targets
+
+There may be instances where you want to use some targets from the common make recipes
+but want to override others.  This requires a little more work, but can be done.
+
+Before doing this, it is worth asking whether what you want to achieve should be
+supported enhancement.  If so, please consider making such a change in preference from using
+this technique.
+
+To completely override the `build` target, for example, so that none of the common make
+`build` target is run, but all of the other common make targets are available, your Makefile might look like this:
+
+```make
+build:
+	go build ./...
+
+%: force
+	@$(MAKE) -f go-common.mk $@
+
+force: ;
+
+.PHONY: build force
+```

--- a/README.md
+++ b/README.md
@@ -82,71 +82,33 @@ include go-common.mk
 ### Include
 
 In all cases the Makefile will ultimately reference one or more of the `*-common.mk`
-files in this package, usually through the use of the `include` directive.  However,
-there are a number of options on how this directive can be resolved.
+files in this package, usually through the use of the `include` directive.  While the
+include directive itself is simple, it is worth mentioning how to obtain the file being
+included.
 
-#### Dynamic download
+While it is possible to have a Make recipe that defines how to create the file being
+included, the recommendation is that a copy of the file be downloaded manually and
+checked in as part of setting up the repository.  The benefits of this include:
 
-In this option, the Makefile includes a target for creating the common make file that
-is included by downloading it from Github as well as an `include` directive.  In this
-case the name of the common make file that is downloaded should be added to
-`.gitignore` for the package so that it is not inadvertently committed.
+* Simple set up for developers (cloning the repository is all they need to do)
+* Consistent behaviour across a development team (all developers are working with the same copy of the common make infrastructure in a given repository)
+* Repositories are fully self-contained
+* The maintainers of the repository are in control of common make updates
 
-`curl` will be used in the following examples to illustrate a variety of forms this
-could take.
+A copy of the common make file infrastructure can be downloaded in a variety of ways,
+including the use of the GitHub Web UI, or the use of a command line tool such as
+`curl`, e.g.
 
-Get the most recent version of `go-common-mk`:
-
-```make
-include go-common.mk
-
-go-common.mk:
-	curl -O -L https://raw.github.com/AchievementNetwork/common-make/master/go-common.mk
+```
+curl -O -L https://raw.github.com/AchievementNetwork/common-make/master/go-common.mk
 ```
 
-Get the version for a specific release:
+The downloaded `go-common.mk` (or whatever common make file is being used) should then
+be added to the local repository with the relevant VCS.
 
-```make
-include go-common.mk
+**The checked in file should not be modified locally, as this will make managing updates more complex**
 
-go-common.mk:
-	curl -O -L https://raw.github.com/AchievementNetwork/common-make/1.0.0/go-common.mk
-```
-
-Get the version for a specific commit:
-
-```make
-include go-common.mk
-
-go-common.mk:
-	curl -O -L https://raw.github.com/AchievementNetwork/common-make/<commit-hash>/go-common.mk
-```
-
-__Pros__
-
-* New common make features will be pulled in automatically as they are added (although see the caveat in the __Cons__ section)
-* Depending on the download recipe used, package maintainers have flexibility in whether they will automatically pick up none, some, or all updates
-
-__Cons__
-
-* All users, including the package builder, must have network access in order to build the package, at least initially
-* Developers may need to periodically to refresh the common make files if another developer starts using the features of a newer version
-
-#### Local copy
-
-In this option, a copy of the appropriate `*-common.mk` file(s) are downloaded manually and
-checked into the package being built.  In this case the Makefile can just use the
-`include` directive with no additional complications.
-
-__Pros__
-
-* The Makefile only needs a simple include statement
-* The package is self-contained and fully in control of pulling in future common make infrastructure updates
-
-__Cons__
-
-* Developers may make local changes to the common make infrastructure which are not fed upstream, making future updates painful or even infeasible in the worst cases
-* The package will not pick up any common make updates without manual intervention
+#### Updates
 
 
 ### Overriding variables

--- a/copy-common.mk
+++ b/copy-common.mk
@@ -1,0 +1,63 @@
+## Variables
+
+## External variables
+# These may be overridden by the repo Makefile
+
+# Standard variables for copied files
+COPY ?= cp
+COPYTARGETS ?=
+COPYFLAGS ?= -r
+
+# Default output directory for executables and associated (copied) files
+BUILDDIR ?= build
+
+ifdef COPYTARGETS
+_COPY_BUILD_TARGETS := $(addprefix $(BUILDDIR)/,$(notdir $(COPYTARGETS)))
+else
+_COPY_BUILD_TARGETS :=
+endif
+
+## Targets
+
+.PHONY: build clean
+.PHONY: pre-build standard-build post-build
+.PHONY: pre-clean standard-clean post-clean
+
+## External targets
+# These may be overridden and used in repo Makefiles
+
+# Build all targets
+build:: pre-build standard-build post-build
+
+pre-build::
+
+standard-build:: $(_COPY_BUILD_TARGETS)
+
+post-build::
+
+# Clean up build artifacts
+clean:: pre-clean standard-clean post-clean
+
+pre-clean::
+
+standard-clean::
+ifdef _COPY_BUILD_TARGETS
+	-$(RM) $(_COPY_BUILD_TARGETS)
+endif
+	-rmdir $(BUILDDIR)
+
+post-clean::
+
+## Internal targets
+# DO NOT OVERRIDE OR USE
+# Overriding may yield undefined results
+# Names may change at any time
+
+# Copy files
+ifdef _COPY_BUILD_TARGETS
+$(_COPY_BUILD_TARGETS): $(COPYTARGETS)
+	$(COPY) $(COPYFLAGS) $(COPYTARGETS) $(BUILDDIR)/
+endif
+
+# Print the value of a variable
+_printvar-copy-%: ; @echo $($*)

--- a/go-common.mk
+++ b/go-common.mk
@@ -1,0 +1,124 @@
+## Variables
+
+## External variables
+# These may be overridden by the repo Makefile
+
+# Default project name
+PROJECT ?= $(shell basename $(CURDIR))
+
+# Standard go variables
+GO ?= go
+GOSRC ?= $(shell find . -name '*.go')
+GOTARGETS ?= $(PROJECT)
+GOROOTTARGET ?=
+GOFLAGS ?=
+GOTESTTARGET ?= ./...
+GOTESTFLAGS ?= -v -race
+GOCMDDIR ?= ./cmd
+
+# Default output directory for executables and associated (copied) files
+BUILDDIR ?= build
+
+## Internal variables
+# DO NOT OVERRIDE
+ifdef GOROOTTARGET
+_GO_BUILD_TARGETS := $(addprefix $(BUILDDIR)/,$(filter-out $(GOROOTTARGET),$(GOTARGETS)))
+_GO_ROOT_BUILD_TARGET := $(addprefix $(BUILDDIR)/,$(GOROOTTARGET))
+else
+_GO_BUILD_TARGETS := $(addprefix $(BUILDDIR)/,$(GOTARGETS))
+_GO_ROOT_BUILD_TARGET :=
+endif
+
+## Targets
+
+.PHONY: build clean lint test testcover
+.PHONY: pre-build standard-build post-build
+.PHONY: pre-clean standard-clean post-clean
+.PHONY: pre-lint standard-lint post-lint
+.PHONY: pre-test standard-test post-test
+.PHONY: pre-testcover standard-testcover post-testcover
+
+## External targets
+# These may be overridden and used in repo Makefiles
+
+# Build all targets
+build:: pre-build standard-build post-build
+
+pre-build::
+
+standard-build:: $(_GO_ROOT_BUILD_TARGET) $(_GO_BUILD_TARGETS)
+
+post-build::
+
+# Clean up build artifacts
+clean:: pre-clean standard-clean post-clean
+
+pre-clean::
+
+standard-clean::
+	-$(RM) $(_GO_BUILD_TARGETS)
+ifdef _GO_ROOT_BUILD_TARGET
+	-$(RM) $(_GO_ROOT_BUILD_TARGET)
+endif
+	-$(RM) coverage.raw coverage.html
+	-rmdir $(BUILDDIR)
+
+post-clean::
+
+# Lint code
+lint:: pre-lint standard-lint post-lint
+
+pre-lint::
+
+standard-lint::
+	@which golangci-lint > /dev/null 2>&1 || \
+		$(GO) get github.com/golangci/golangci-lint/cmd/golangci-lint
+	golangci-lint run
+
+post-lint::
+
+# Run unit tests
+test:: pre-test standard-test post-test
+
+pre-test::
+
+standard-test::
+	$(GO) test $(GOTESTFLAGS) $(GOTESTTARGET)
+
+post-test::
+
+testcover:: pre-testcover standard-testcover post-testcover
+
+pre-testcover::
+
+standard-testcover:: coverage.html
+
+post-testcover::
+
+## Internal targets
+# DO NOT OVERRIDE OR USE
+# Overriding may yield undefined results
+# Names may change at any time
+
+# Test coverage files
+coverage.raw:
+	$(GO) test $(GOTESTFLAGS) -coverprofile=$@ $(GOTESTTARGET)
+
+coverage.html: coverage.raw
+	$(GO) tool cover -html=$< -o $@
+
+# Go executables
+$(_GO_ROOT_BUILD_TARGET): $(GOSRC)
+	@-mkdir build 2> /dev/null
+	$(GO) generate ./...
+	$(GO) get ./...
+	$(GO) build $(GOFLAGS) -o $@ .
+
+$(_GO_BUILD_TARGETS): $(GOSRC)
+	@-mkdir build 2> /dev/null
+	$(GO) generate ./...
+	$(GO) get ./...
+	$(GO) build $(GOFLAGS) -o $@ $(GOCMDDIR)/$(notdir $@)
+
+# Print the value of a variable
+_printvar-go-%: ; @echo $($*)

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+TEST=`pwd`
+TEST=`basename $TEST`
+
+fail() {
+	if [ -n "$1" ]; then
+		echo "$1 FAILED" 1>&2
+	fi
+	echo
+	echo "${TEST}: Failed"
+	echo
+	exit 1
+}
+
+make build || fail "Build"
+for EXE in `make -s _printvar-go-GOTARGETS`; do
+	if [ ! -x "build/${EXE}" ]; then
+		fail "Build Go"
+	fi
+done
+for FILE in `make -s _printvar-copy-COPYTARGETS`; do
+	if [ ! -e "build/`basename ${FILE}`" ]; then
+		fail "Build Copy"
+	fi
+done
+
+make test || fail "Test"
+
+make testcover
+if [ ! -f coverage.html ]; then
+	fail "Test Coverage"
+fi
+
+make clean
+if [ -d build ]; then
+	fail "Clean"
+fi
+
+echo
+echo "${TEST}: Success"
+echo

--- a/test/test01/Makefile
+++ b/test/test01/Makefile
@@ -1,0 +1,1 @@
+include ../../go-common.mk

--- a/test/test01/README.md
+++ b/test/test01/README.md
@@ -1,0 +1,3 @@
+Simplest case
+
+A single Go executable is built, just using default values

--- a/test/test01/cmd/test01/main.go
+++ b/test/test01/cmd/test01/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world")
+}

--- a/test/test01/go.mod
+++ b/test/test01/go.mod
@@ -1,0 +1,3 @@
+module github.com/AchievementNetwork/common-make/test/test01
+
+go 1.15

--- a/test/test02/Makefile
+++ b/test/test02/Makefile
@@ -1,0 +1,3 @@
+GOTARGETS=$(PROJECT) aux
+
+include ../../go-common.mk

--- a/test/test02/README.md
+++ b/test/test02/README.md
@@ -1,0 +1,3 @@
+Multiple executables
+
+Two go executables are built, both in standard locations

--- a/test/test02/cmd/aux/main.go
+++ b/test/test02/cmd/aux/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world")
+}

--- a/test/test02/cmd/test02/main.go
+++ b/test/test02/cmd/test02/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world")
+}

--- a/test/test02/go.mod
+++ b/test/test02/go.mod
@@ -1,0 +1,3 @@
+module github.com/AchievementNetwork/common-make/test/test2
+
+go 1.15

--- a/test/test03/Makefile
+++ b/test/test03/Makefile
@@ -1,0 +1,4 @@
+GOTARGETS=$(PROJECT) aux
+GOROOTTARGET=$(PROJECT)
+
+include ../../go-common.mk

--- a/test/test03/README.md
+++ b/test/test03/README.md
@@ -1,0 +1,4 @@
+Multiple executables
+
+Multiple go executables are built, but one is in the repo root
+rather than a standard subdirectory

--- a/test/test03/cmd/aux/main.go
+++ b/test/test03/cmd/aux/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world")
+}

--- a/test/test03/go.mod
+++ b/test/test03/go.mod
@@ -1,0 +1,3 @@
+module github.com/AchievementNetwork/common-make/test/test03
+
+go 1.15

--- a/test/test03/main.go
+++ b/test/test03/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world")
+}

--- a/test/test04/Makefile
+++ b/test/test04/Makefile
@@ -1,0 +1,10 @@
+COPYTARGETS=data/foo data/bar
+
+pre-build::
+	@echo "This should show up once pre-build"
+
+post-build::
+	@echo "This should show up once post-build"
+
+include ../../go-common.mk
+include ../../copy-common.mk

--- a/test/test04/README.md
+++ b/test/test04/README.md
@@ -1,0 +1,4 @@
+Go targets and copy targets
+
+A standard Go executable is built, but there are additional
+files that must be copied into the build

--- a/test/test04/cmd/test04/main.go
+++ b/test/test04/cmd/test04/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world")
+}

--- a/test/test04/go.mod
+++ b/test/test04/go.mod
@@ -1,0 +1,3 @@
+module github.com/AchievementNetwork/common-make/test/test04
+
+go 1.15

--- a/test/test05/Makefile
+++ b/test/test05/Makefile
@@ -1,0 +1,16 @@
+build:
+	@mkdir -p build
+	touch build/test05
+	chmod u+x build/test05
+
+test:
+
+testcover:
+	touch coverage.html
+
+%: force
+	@$(MAKE) -f ../../go-common.mk $@
+
+force: ;
+
+.PHONY: build force test testcover

--- a/test/test05/README.md
+++ b/test/test05/README.md
@@ -1,0 +1,4 @@
+Target ovveride
+
+Override multiple targets.  Other targets (e.g. clean) function
+normally.


### PR DESCRIPTION
* Composable Go and Copy make recipes
* Default Go usage will build a single target based on the repo name
* Go targets are: build, clean, lint, test, and testcover
* Multiple targets can be added
* Copy recipes support copying in additional files to the build directory
* Copy targets are: build, clean
* Provide pre-, standard-, and post- sub-targets for each main target
* Variables and targets can be overridden
* Simple testing framework
* Usage instructions