### PR TITLE
QT-1138 Library support for common make

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These variables are used by the standard targets and may be overridden:
 * __GOTARGETS__ - A list of the executables to build.  Defaults to the project name
 * __GOCMDDIR__ - The location of the directory containing the sub-directories for the executables to be built.  Defaults to `./cmd`
 * __GOROOTTARGET__ - Can be set to the name of a single target from `GOTARGETS` if the main executable code for it is in the top level directory.  No default
+* __GOLIBRARYTARGET__ - A target to pass to `go build` when an executable shouldn't be produced.  It would typically be set to `./...` in that situation.  No default
 * __GOSRC__ - A list of the Go source files.  Defaults to all Go source files recursively found in the current directory
 * __GO__ - The Go executable to run.  Defaults to `go`
 * __GOFLAGS__ - Flags to pass to `go build`.  No default

--- a/go-common.mk
+++ b/go-common.mk
@@ -19,6 +19,7 @@ GO ?= go
 GOSRC ?= $(shell find . -name '*.go')
 GOTARGETS ?= $(PROJECT)
 GOROOTTARGET ?=
+GOLIBRARYTARGET ?=
 GOFLAGS ?=
 GOTESTTARGET ?= ./...
 GOTESTFLAGS ?= -v -race
@@ -33,8 +34,13 @@ ifdef GOROOTTARGET
 _GO_BUILD_TARGETS := $(addprefix $(BUILDDIR)/,$(filter-out $(GOROOTTARGET),$(GOTARGETS)))
 _GO_ROOT_BUILD_TARGET := $(addprefix $(BUILDDIR)/,$(GOROOTTARGET))
 else
+ifdef GOTARGETS
 _GO_BUILD_TARGETS := $(addprefix $(BUILDDIR)/,$(GOTARGETS))
 _GO_ROOT_BUILD_TARGET :=
+else
+_GO_BUILD_TARGETS :=
+_GO_ROOT_BUILD_TARGET :=
+endif
 endif
 
 ## Targets
@@ -56,6 +62,11 @@ build:: pre-build standard-build post-build
 pre-build::
 
 standard-build:: $(_GO_ROOT_BUILD_TARGET) $(_GO_BUILD_TARGETS)
+ifdef GOLIBRARYTARGET
+	$(GO) generate ./...
+	$(GO) get ./...
+	$(GO) build $(GOFLAGS) $(GOLIBRARYTARGET)
+endif
 
 post-build::
 
@@ -65,7 +76,9 @@ clean:: pre-clean standard-clean post-clean
 pre-clean::
 
 standard-clean::
+ifdef _GO_BUILD_TARGETS
 	-$(RM) $(_GO_BUILD_TARGETS)
+endif
 ifdef _GO_ROOT_BUILD_TARGET
 	-$(RM) $(_GO_ROOT_BUILD_TARGET)
 endif

--- a/test/test06/Makefile
+++ b/test/test06/Makefile
@@ -1,0 +1,4 @@
+GOTARGETS=
+GOLIBRARYTARGET=./...
+
+include ../../go-common.mk

--- a/test/test06/README.md
+++ b/test/test06/README.md
@@ -1,0 +1,3 @@
+Library case
+
+No executable is built

--- a/test/test06/go.mod
+++ b/test/test06/go.mod
@@ -1,0 +1,3 @@
+module github.com/AchievementNetwork/common-make/test/test06
+
+go 1.15

--- a/test/test06/pkg/lib/lib.go
+++ b/test/test06/pkg/lib/lib.go
@@ -1,0 +1,7 @@
+package lib
+
+import "fmt"
+
+func Print(message string) {
+	fmt.Println(message)
+}


### PR DESCRIPTION
* Add support for building Go repositories which are "libraries".  That is, repositories which aren't applications, but contain Go modules which are used by other applications.  In this situation, the build produces no executable.
* Add a test for this situation
* Update documentation