### PR TITLE
[IN-246] Determine the project name from the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ actions for `standard-` sub-target.  The others are provided to allow custom act
 
 These variables are used by the standard targets and may be overridden:
 
-* __PROJECT__ - The name of the project being built.  Defaults to the name of the current directory (which should be also the name of the repository)
+* __PROJECT__ - The name of the project being built.  Defaults to the name of the repository or the current directory (if there is no git repository)
 * __BUILDDIR__ - The location that build artifacts will be placed in.  Defaults to `./build`
 * __GOTARGETS__ - A list of the executables to build.  Defaults to the project name
 * __GOCMDDIR__ - The location of the directory containing the sub-directories for the executables to be built.  Defaults to `./cmd`

--- a/go-common.mk
+++ b/go-common.mk
@@ -12,7 +12,12 @@
 # These may be overridden by the repo Makefile
 
 # Default project name
+PROJECT_REPO_URL := $(shell git config --get remote.origin.url 2> /dev/null)
+ifdef PROJECT_REPO_URL
+PROJECT ?= $(shell basename -s .git $(PROJECT_REPO_URL))
+else
 PROJECT ?= $(shell basename $(CURDIR))
+endif
 
 # Standard go variables
 GO ?= go

--- a/test/test01/Makefile
+++ b/test/test01/Makefile
@@ -1,1 +1,3 @@
+PROJECT=$(shell basename $(CURDIR))
+
 include ../../go-common.mk

--- a/test/test02/Makefile
+++ b/test/test02/Makefile
@@ -1,3 +1,4 @@
+PROJECT=$(shell basename $(CURDIR))
 GOTARGETS=$(PROJECT) aux
 
 include ../../go-common.mk

--- a/test/test04/Makefile
+++ b/test/test04/Makefile
@@ -1,3 +1,4 @@
+PROJECT=$(shell basename $(CURDIR))
 COPYTARGETS=data/foo data/bar
 
 pre-build::

--- a/test/test05/Makefile
+++ b/test/test05/Makefile
@@ -1,3 +1,5 @@
+PROJECT=$(shell basename $(CURDIR))
+
 build:
 	@mkdir -p build
 	touch build/test05
@@ -9,7 +11,7 @@ testcover:
 	touch coverage.html
 
 %: force
-	@$(MAKE) -f ../../go-common.mk $@
+	@$(MAKE) PROJECT=$(PROJECT) -f ../../go-common.mk $@
 
 force: ;
 


### PR DESCRIPTION
* Determine the project name from the git repository URL if that is present, and the current directory if not.

  CircleCI, by default, doesn't put the project in a directory named after the project.   Without this change all of our CircleCI configurations must set working_directory otherwise the build will fail as a result.
* Adjust the test Makefiles to set PROJECT per the previous default as needed
* Update documentation