### PR TITLE
[IN-236] Allow control of the location of coverage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ These variables are used by the standard targets and may be overridden:
 * __GOFLAGS__ - Flags to pass to `go build`.  No default
 * __GOTESTTARGET__ - The target to pass to `go test`.  Defaults to `./...`, which means all tests in the project
 * __GOTESTFLAGS__ - Flags to pass to `go test`.  Defaults to `-v -race`
+* __GOTESTCOVERRAW__ - File to write raw test coverage data to.  Defaults to `coverage.raw`
+* __GOTESTCOVERHTML__ - File to write HTML formatted test coverage data to.  Defaults to `coverage.html`
 
 
 ## Copy

--- a/go-common.mk
+++ b/go-common.mk
@@ -28,6 +28,8 @@ GOLIBRARYTARGET ?=
 GOFLAGS ?=
 GOTESTTARGET ?= ./...
 GOTESTFLAGS ?= -v -race
+GOTESTCOVERRAW ?= coverage.raw
+GOTESTCOVERHTML ?= coverage.html
 GOCMDDIR ?= ./cmd
 
 # Default output directory for executables and associated (copied) files
@@ -87,7 +89,7 @@ endif
 ifdef _GO_ROOT_BUILD_TARGET
 	-$(RM) $(_GO_ROOT_BUILD_TARGET)
 endif
-	-$(RM) coverage.raw coverage.html
+	-$(RM) $(GOTESTCOVERRAW) $(GOTESTCOVERHTML)
 	-rmdir $(BUILDDIR)
 
 post-clean::
@@ -118,7 +120,7 @@ testcover:: pre-testcover standard-testcover post-testcover
 
 pre-testcover::
 
-standard-testcover:: coverage.html
+standard-testcover:: $(GOTESTCOVERHTML)
 
 post-testcover::
 
@@ -145,10 +147,10 @@ _commonupdate::
 # Names may change at any time
 
 # Test coverage files
-coverage.raw:
+$(GOTESTCOVERRAW):
 	$(GO) test $(GOTESTFLAGS) -coverprofile=$@ $(GOTESTTARGET)
 
-coverage.html: coverage.raw
+$(GOTESTCOVERHTML): $(GOTESTCOVERRAW)
 	$(GO) tool cover -html=$< -o $@
 
 # Go executables


### PR DESCRIPTION
* Allow projects to override the location that code coverage is output to
* Document the variables that control this and the defaults.

This means build systems that want to preserve these build artifacts can set locations and aren't coupled to undocumented details.