### PR TITLE
[IN=236] Add settings for finer build control

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ These variables are used by the standard targets and may be overridden:
 * __GOSRC__ - A list of the Go source files.  Defaults to all Go source files recursively found in the current directory
 * __GO__ - The Go executable to run.  Defaults to `go`
 * __GOFLAGS__ - Flags to pass to `go build`.  No default
+* __GORUNGET__ - Run `go get` prior to building if defined.  Defaults to defined
+* __GORUNGENERATE__ - Run `go generate` prior to building if defined.  Defaults to defined
 * __GOTESTTARGET__ - The target to pass to `go test`.  Defaults to `./...`, which means all tests in the project
 * __GOTESTFLAGS__ - Flags to pass to `go test`.  Defaults to `-v -race`
 * __GOTESTCOVERRAW__ - File to write raw test coverage data to.  Defaults to `coverage.raw`

--- a/go-common.mk
+++ b/go-common.mk
@@ -20,17 +20,19 @@ PROJECT ?= $(shell basename $(CURDIR))
 endif
 
 # Standard go variables
-GO ?= go
-GOSRC ?= $(shell find . -name '*.go')
 GOTARGETS ?= $(PROJECT)
+GOCMDDIR ?= ./cmd
 GOROOTTARGET ?=
 GOLIBRARYTARGET ?=
+GOSRC ?= $(shell find . -name '*.go')
+GO ?= go
 GOFLAGS ?=
+GORUNGENERATE ?= yes
+GORUNGET ?= yes
 GOTESTTARGET ?= ./...
 GOTESTFLAGS ?= -v -race
 GOTESTCOVERRAW ?= coverage.raw
 GOTESTCOVERHTML ?= coverage.html
-GOCMDDIR ?= ./cmd
 
 # Default output directory for executables and associated (copied) files
 BUILDDIR ?= build
@@ -70,8 +72,12 @@ pre-build::
 
 standard-build:: $(_GO_ROOT_BUILD_TARGET) $(_GO_BUILD_TARGETS)
 ifdef GOLIBRARYTARGET
+ifdef GORUNGENERATE
 	$(GO) generate ./...
+endif # GORUNGENERATE
+ifdef GORUNGET
 	$(GO) get ./...
+endif # GORUNGET
 	$(GO) build $(GOFLAGS) $(GOLIBRARYTARGET)
 endif
 
@@ -156,14 +162,22 @@ $(GOTESTCOVERHTML): $(GOTESTCOVERRAW)
 # Go executables
 $(_GO_ROOT_BUILD_TARGET): $(GOSRC)
 	@-mkdir build 2> /dev/null
+ifdef GORUNGENERATE
 	$(GO) generate ./...
+endif # GORUNGENERATE
+ifdef GORUNGET
 	$(GO) get ./...
+endif # GORUNGET
 	$(GO) build $(GOFLAGS) -o $@ .
 
 $(_GO_BUILD_TARGETS): $(GOSRC)
 	@-mkdir build 2> /dev/null
+ifdef GORUNGENERATE
 	$(GO) generate ./...
+endif # GORUNGENERATE
+ifdef GORUNGET
 	$(GO) get ./...
+endif # GORUNGET
 	$(GO) build $(GOFLAGS) -o $@ $(GOCMDDIR)/$(notdir $@)
 
 # Print the value of a variable


### PR DESCRIPTION
* Add variables which allow `go get` and `go generate` to be turned off by individual projects if needed.

#### Motivation

Running `go get` during the build of ads-session-mapping causes errors due to the Kafka packages it uses and their native dependencies.  The current build of that package, as a result, does not run `go get`, so this allows common make to be used by it.