### PR TITLE
Make sure all testing modules are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These variables are used by the standard targets and may be overridden:
 * __GOSRC__ - A list of the Go source files.  Defaults to all Go source files recursively found in the current directory
 * __GO__ - The Go executable to run.  Defaults to `go`
 * __GOFLAGS__ - Flags to pass to `go build`.  No default
-* __GORUNGET__ - Run `go get` prior to building if defined.  Defaults to defined
+* __GORUNGET__ - Run `go get` prior to building/testing if defined.  Defaults to defined
 * __GORUNGENERATE__ - Run `go generate` prior to building if defined.  Defaults to defined
 * __GOTESTTARGET__ - The target to pass to `go test`.  Defaults to `./...`, which means all tests in the project
 * __GOTESTFLAGS__ - Flags to pass to `go test`.  Defaults to `-v -race`

--- a/go-common.mk
+++ b/go-common.mk
@@ -118,6 +118,9 @@ test:: pre-test standard-test post-test
 pre-test::
 
 standard-test::
+ifdef GORUNGET
+	$(GO) get -t ./...
+endif # GORUNGET
 	$(GO) test $(GOTESTFLAGS) $(GOTESTTARGET)
 
 post-test::
@@ -154,6 +157,9 @@ _commonupdate::
 
 # Test coverage files
 $(GOTESTCOVERRAW):
+ifdef GORUNGET
+	$(GO) get -t ./...
+endif # GORUNGET
 	$(GO) test $(GOTESTFLAGS) -coverprofile=$@ $(GOTESTTARGET)
 
 $(GOTESTCOVERHTML): $(GOTESTCOVERRAW)


### PR DESCRIPTION
* If `GORUNGET` is set, run `go get -t` prior to running unit tests to ensure all of the modules required to run the tests are also present.