### PR TITLE
Standardise test coverage fixes

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -164,6 +164,12 @@ endif # GORUNGET
 
 $(GOTESTCOVERHTML): $(GOTESTCOVERRAW)
 	$(GO) tool cover -html=$< -o $@
+	# To allow Code Climate to understand our uploaded coverage files
+	case "$$(grep '^module' go.mod | awk -F/ '{print$$NF}')" in \
+		v[0-9]) \
+			sed -i'' -e 's!/v[0-9]/!/!' "$(GOTESTCOVERRAW)" "$(GOTESTCOVERHTML)" \
+			;; \
+	esac
 
 # Go executables
 $(_GO_ROOT_BUILD_TARGET): $(GOSRC)


### PR DESCRIPTION
* Putting the versioning into go.mod directly means that our coverage reports confuse Code Climate since it can't find the files being referred to in them.  Our libraries that are at v2 or higher have ended up adding a post-testcover target that fixes this.  The change here moves that into the common make code.

  One implication/limitation of this is that we're going to do our module versions at the top level as a convention rather than in sub-directories.  Most of the Go projects I've seen on GitHub appear to follow this convention, so that doesn't seem overly burdensome.