### PR TITLE
Add a GODEBUG flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These variables are used by the standard targets and may be overridden:
 * __GOSRC__ - A list of the Go source files.  Defaults to all Go source files recursively found in the current directory
 * __GO__ - The Go executable to run.  Defaults to `go`
 * __GOFLAGS__ - Flags to pass to `go build`.  No default
+* __GODEBUG__ - Build executable without optimisation and inlining if defined.  Defaults to undefined.
 * __GORUNGET__ - Run `go get` prior to building/testing if defined.  Defaults to defined
 * __GORUNGENERATE__ - Run `go generate` prior to building if defined.  Defaults to defined
 * __GOTESTTARGET__ - The target to pass to `go test`.  Defaults to `./...`, which means all tests in the project

--- a/go-common.mk
+++ b/go-common.mk
@@ -26,6 +26,7 @@ GOROOTTARGET ?=
 GOLIBRARYTARGET ?=
 GOSRC ?= $(shell find . -name '*.go')
 GO ?= go
+GODEBUG ?=
 GOFLAGS ?=
 GORUNGENERATE ?= yes
 GORUNGET ?= yes
@@ -49,8 +50,12 @@ _GO_ROOT_BUILD_TARGET :=
 else
 _GO_BUILD_TARGETS :=
 _GO_ROOT_BUILD_TARGET :=
-endif
-endif
+endif # GOTARGETS
+endif # GOROOTTARGET
+
+ifdef GODEBUG
+GOFLAGS += -gcflags "all=-N -l"
+endif # GODEBUG
 
 ## Targets
 


### PR DESCRIPTION
* If GODEBUG is set the executables will be built with inlining and optimisation disabled, which is often helpful when stepping through Go executables with a debugger.  Defaults to off.