### PR TITLE
use install@version command to install golangci-lint without adding deps to module

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -112,7 +112,7 @@ pre-lint::
 
 standard-lint::
 	@which golangci-lint > /dev/null 2>&1 || \
-		$(GO) get github.com/golangci/golangci-lint/cmd/golangci-lint
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run
 
 post-lint::


### PR DESCRIPTION
golangci-lint hasn't been working for me locally because of [long story](https://github.com/golangci/golangci-lint/issues/2374) short go1.18 requires a newer version of golangci-lint than had been installed by go-common.mk in the past.

The fix was to delete my local install of golangci-lint and install the latest version, but using `go get` adds all the dependencies to `go.mod` but in go1.16 they [added](https://go-review.googlesource.com/c/go/+/254365) this install@version command  which is now the way to install packages without modifying the module.

Ideally there would be some way to keep the version of golangci-lint up to date on our computers but that seems a larger task.