### PR TITLE
non-verbose go tests

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -31,7 +31,7 @@ GOFLAGS ?=
 GORUNGENERATE ?= yes
 GORUNGET ?= yes
 GOTESTTARGET ?= ./...
-GOTESTFLAGS ?= -v -race
+GOTESTFLAGS ?= -race
 GOTESTCOVERRAW ?= coverage.raw
 GOTESTCOVERHTML ?= coverage.html
 


### PR DESCRIPTION
Teeny suggestion for our go tests!

With the -v flag, `go test` prints out a list of the names of every test case in the entire project, plus all their stdout output. Without that flag, it prints only the names and stdout output of those test cases that failed, and suppresses the names and output of successful test cases. The current behavior is that the console output gets flooded with uninformative text about successful test cases, and it can be difficult to find the actual failed test cases and figure out how to fix them.