### PR TITLE
[IN-433] Install golangci-lint using `go install`

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -112,7 +112,7 @@ pre-lint::
 
 standard-lint::
 	@which golangci-lint > /dev/null 2>&1 || \
-		$(GO) get github.com/golangci/golangci-lint/cmd/golangci-lint
+		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint
 	golangci-lint run
 
 post-lint::


### PR DESCRIPTION
* Modern Go versions would prefer we use `go install` to install tools, instead of `go get`

  I think the other uses of `go get` in here are ok