### PR TITLE
IAM-1420 allow build-only flags

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -27,7 +27,7 @@ GOLIBRARYTARGET ?=
 GOSRC ?= $(shell find . -name '*.go')
 GO ?= go
 GODEBUG ?=
-GOFLAGS ?=
+GOBUILDFLAGS ?=
 GORUNGENERATE ?= yes
 GORUNGET ?= yes
 GOTESTTARGET ?= ./...
@@ -54,7 +54,7 @@ endif # GOTARGETS
 endif # GOROOTTARGET
 
 ifdef GODEBUG
-GOFLAGS += -gcflags "all=-N -l"
+GOBUILDFLAGS += -gcflags "all=-N -l"
 endif # GODEBUG
 
 ## Targets
@@ -83,7 +83,7 @@ endif # GORUNGENERATE
 ifdef GORUNGET
 	$(GO) get ./...
 endif # GORUNGET
-	$(GO) build $(GOFLAGS) $(GOLIBRARYTARGET)
+	$(GO) build $(GOBUILDFLAGS) $(GOLIBRARYTARGET)
 endif
 
 post-build::
@@ -186,7 +186,7 @@ endif # GORUNGENERATE
 ifdef GORUNGET
 	$(GO) get ./...
 endif # GORUNGET
-	$(GO) build $(GOFLAGS) -o $@ .
+	$(GO) build $(GOBUILDFLAGS) -o $@ .
 
 $(_GO_BUILD_TARGETS): $(GOSRC) go.mod
 	@-mkdir $(BUILDDIR) 2> /dev/null
@@ -196,7 +196,7 @@ endif # GORUNGENERATE
 ifdef GORUNGET
 	$(GO) get ./...
 endif # GORUNGET
-	$(GO) build $(GOFLAGS) -o $@ $(GOCMDDIR)/$(notdir $@)
+	$(GO) build $(GOBUILDFLAGS) -o $@ $(GOCMDDIR)/$(notdir $@)
 
 # Print the value of a variable
 _printvar-go-%: ; @echo $($*)


### PR DESCRIPTION
# Summary

This PR fixes a minor bug and also exposes a new feature.

`GOFLAGS` is a builtin envar that, when set, is automatically passed to all go toolchain commands. The current implementation of `go-common.mk` misuses this envar, in a couple ways:
- It passes the value of GOFLAGS explicitly on the command line to any `go build` commands, which is redundant
- When GODEBUG is set, it populates GOFLAGS with flags that are only valid for `go build`, not all go toolchain commands, which causes some other go toolchain commands (such as `get` and `generate`) to fail
- Even when only `go build` is being called (such as when running `GORUNGENERATE= GORUNGET= GODEBUG=1 make generate`) putting the special flags into GOFLAGS rather than directly in the command line seems to cause them to be parsed incorrectly

I've renamed GOFLAGS to GOBUILDFLAGS throughout the file. This has the following effects:
- The special debug flags no longer mess with non-build commands
- The special debug flags are parsed properly
- The name GOBUILDFLAGS provides a new hook for services (such as iam-api) to pass their own special flags meant _only_ for the build command, since this envar isn't used for any special purpose internally by the go toolchain. If a services wants to pass flags to _all_ go toolchain commands, this is already possible by using GOFLAGS, without go-common needing to provide any special support for it

# Checklist
- [ ] Are there any failing automated checks, and if so, have you left an explanation for reviewers?
