### PR TITLE
Increase lint timeout

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -34,6 +34,7 @@ GOTESTTARGET ?= ./...
 GOTESTFLAGS ?= -race
 GOTESTCOVERRAW ?= coverage.raw
 GOTESTCOVERHTML ?= coverage.html
+GOLINTFLAGS ?= --timeout 2m
 
 # Default output directory for executables and associated (copied) files
 BUILDDIR ?= build
@@ -113,7 +114,7 @@ pre-lint::
 standard-lint::
 	@which golangci-lint > /dev/null 2>&1 || \
 		$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	golangci-lint run
+	golangci-lint run $(GOLINTFLAGS)
 
 post-lint::
 


### PR DESCRIPTION
# Summary

* Allow passing flags to golangci-lint
* By default pass an increased timeout (double the default)

# Motivation

I often see iam-api time out in CircleCI on the lint step.  I've also seen it for quiz-api.  This will hopefully address the issue