### PR TITLE
ignore fakes in go codecoverage

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -176,7 +176,9 @@ _commonupdate::
 
 # Test coverage files
 $(GOTESTCOVERRAW):
-	$(GOTESTENV) $(GO) test $(GOTESTFLAGS) -coverprofile=$@ $(GOTESTTARGET)
+	$(GOTESTENV) $(GO) test $(GOTESTFLAGS) -coverprofile=cover.out.tmp $(GOTESTTARGET)
+	grep -v "fake_" cover.out.tmp > $@
+	rm cover.out.tmp
 
 $(GOTESTCOVERHTML): $(GOTESTCOVERRAW)
 	$(GO) tool cover -html=$< -o $@


### PR DESCRIPTION
# Summary

@bmalaguti-anet added this to learnosity-mirror recently to improve code coverage stats by ignoring fakes, and I thought it seemed like a good candidate to put here for re-use.