### PR TITLE
treat coverage files as phony to allow easy rerunning

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -71,6 +71,7 @@ endif # GODEBUG
 .PHONY: pre-test standard-test post-test
 .PHONY: pre-testcover standard-testcover post-testcover
 .PHONY: _checkcommonupdate _commonupdate
+.PHONY: $(GOTESTCOVERRAW) $(GOTESTCOVERHTML)
 
 ## External targets
 # These may be overridden and used in repo Makefiles

--- a/go-common.mk
+++ b/go-common.mk
@@ -71,7 +71,6 @@ endif # GODEBUG
 .PHONY: pre-test standard-test post-test
 .PHONY: pre-testcover standard-testcover post-testcover
 .PHONY: _checkcommonupdate _commonupdate
-.PHONY: $(GOTESTCOVERRAW) $(GOTESTCOVERHTML)
 
 ## External targets
 # These may be overridden and used in repo Makefiles
@@ -176,7 +175,7 @@ _commonupdate::
 # Names may change at any time
 
 # Test coverage files
-$(GOTESTCOVERRAW):
+$(GOTESTCOVERRAW): $(shell find . -type f -name '*_test.go')
 	$(GOTESTENV) $(GO) test $(GOTESTFLAGS) -coverprofile=cover.out.tmp $(GOTESTTARGET)
 	grep -v "fake_" cover.out.tmp > $@
 	rm cover.out.tmp

--- a/go-common.mk
+++ b/go-common.mk
@@ -175,7 +175,7 @@ _commonupdate::
 # Names may change at any time
 
 # Test coverage files
-$(GOTESTCOVERRAW): $(shell find . -type f -name '*_test.go')
+$(GOTESTCOVERRAW): $(GOSRC)
 	$(GOTESTENV) $(GO) test $(GOTESTFLAGS) -coverprofile=cover.out.tmp $(GOTESTTARGET)
 	grep -v "fake_" cover.out.tmp > $@
 	rm cover.out.tmp


### PR DESCRIPTION
# Summary

Mark these files as phony so that `make testcover` can be run repeatedly.

# Checklist
- [ ] Did you add or remove any calls to a service or frontend?
    - [ ] Update the API dependency inventory
- [ ] Is this a backend service?
    - [ ] Did you add any new endpoints or change the contract/signature of an endpoint?
    	- [ ] Have you updated the OpenAPI specs for this service?
    	- [ ] Have you updated Spring contracts for this service?
    - [ ] Did you add any new database migrations?
    	- [ ] Do you need to add indexes?
	    - [ ] Have the migrations been tested?
- [ ] If this is a frontend application, can you still run the application locally using the provided script/command?
- [ ] Is this a client library, do you need to update the consumer contract tests?
- [ ] Are there any failing automated checks, and if so, have you left an explanation for reviewers?
