### PR TITLE
[IN-887] Allow overriding of the test command

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -33,6 +33,7 @@ GORUNGENERATE ?= yes
 GOGENERATEENV ?=
 GOTESTTARGET ?= ./...
 GOTESTFLAGS ?= -race
+GOTEST ?= $(GO) test
 GOTESTENV ?=
 GOTESTCOVERRAW ?= coverage.raw
 GOTESTCOVERHTML ?= coverage.html
@@ -140,7 +141,7 @@ test:: pre-test standard-test post-test
 pre-test::
 
 standard-test:: generate
-	$(GOTESTENV) $(GO) test $(GOTESTFLAGS) $(GOTESTTARGET)
+	$(GOTESTENV) $(GOTEST) $(GOTESTFLAGS) $(GOTESTTARGET)
 
 post-test::
 
@@ -176,7 +177,7 @@ _commonupdate::
 
 # Test coverage files
 $(GOTESTCOVERRAW): $(GOSRC)
-	$(GOTESTENV) $(GO) test $(GOTESTFLAGS) -coverprofile=cover.out.tmp $(GOTESTTARGET)
+	$(GOTESTENV) $(GOTEST) $(GOTESTFLAGS) -coverprofile=cover.out.tmp $(GOTESTTARGET)
 	grep -v "fake_" cover.out.tmp > $@
 	rm cover.out.tmp
 


### PR DESCRIPTION
# Summary

* The current set up allows overriding of the `$(GO)` command, but forces tests to be run with the subcommand `test` of whatever `$(GO)` is.  Keep this as the default, but allow the overall test command to be overridden is desired by defining it as `$(GOTEST)`.

This allows the use of wrappers or alternatives that may integrate better with CircleCI's test infrastructure, while preserving existing behaviour unless that is desired.

See https://github.com/AchievementNetwork/pizza/pull/134 for an example use of this

# Checklist
- [ ] Did you add or remove any calls to a service or frontend?
    - [ ] Update the API dependency inventory
- [ ] Is this a backend service?
    - [ ] Did you add any new endpoints or change the contract/signature of an endpoint?
    	- [ ] Have you updated the OpenAPI specs for this service?
    	- [ ] Have you updated Spring contracts for this service?
    - [ ] Did you add any new database migrations?
    	- [ ] Do you need to add indexes?
	    - [ ] Have the migrations been tested?
- [ ] If this is a frontend application, can you still run the application locally using the provided script/command?
- [ ] Is this a client library, do you need to update the consumer contract tests?
- [ ] Are there any failing automated checks, and if so, have you left an explanation for reviewers?
