### PR TITLE
[IN-995] Update to golangci-lint v2

### DIFF
--- a/go-common.mk
+++ b/go-common.mk
@@ -37,7 +37,7 @@ GOTESTENV ?=
 GOTESTCOVERRAW ?= coverage.raw
 GOTESTCOVERHTML ?= coverage.html
 GOLINTFLAGS ?= --timeout 5m
-GOLINTERIMPORTPATH ?= github.com/golangci/golangci-lint/cmd/golangci-lint
+GOLINTERIMPORTPATH ?= github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
 # Default output directory for executables and associated (copied) files
 BUILDDIR ?= build
@@ -130,7 +130,7 @@ standard-lint:: generate
 			eval "$$_common_make_no_tools_lint_help"; \
 		  fi; \
 		  exit 1 )
-	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint run $(GOLINTFLAGS)
+	$(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint run $(GOLINTFLAGS)
 
 post-lint::
 
@@ -216,7 +216,7 @@ Please create a top level tools.go file with contents like
 
 package tools
 
-import _ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+import _ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 -
 
 (the package may need adjusting) and then run 'go mod tidy'.
@@ -230,7 +230,7 @@ define __common_make_tools_lint_help
 cat <<EOF
 No dependency on golangci-lint found!
 
-Please add an import of "github.com/golangci/golangci-lint/cmd/golangci-lint"
+Please add an import of "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 to the tools.go file and then run 'go mod tidy'.
 
 Then commit the changes to the file and changes to 'go.mod' and 'go.sum'.


### PR DESCRIPTION
# Summary

* Alter the golangci-lint path references to include `v2`

## Context

Currently all of our projects use golangci-lint v1, which has a dependency on `github.com/tdakkota/asciicheck`.  This package has recently been deleted, which is causing dependeabot failures.  It would also cause failures for anyone who doesn't have the package cached locally (since they would be unable to download it).  This dependency has been replaced by `github.com/golangci/asciicheck` in golangci-lint v2.

## Notes

Projects will need other changes when they pick up this new version of `go-common.mk`.  Typically this will mean updating the golangci-lint dependency in `go.mod` (and `go.sum`) to be a `v2` dependency with an appropriate version (latest is 2.12.2 IIRC), as well as updating the import in `tools.go`. 

I've chosen a hardcoded v2 upgrade here rather than something more flexible since v1 is broken.

# Checklist
- [ ] Did you add or remove any calls to a service or frontend?
    - [ ] Update the API dependency inventory
- [ ] Is this a backend service?
    - [ ] Did you add any new endpoints or change the contract/signature of an endpoint?
    	- [ ] Have you updated the OpenAPI specs for this service?
    	- [ ] Have you updated Spring contracts for this service?
    - [ ] Did you add any new database migrations?
    	- [ ] Do you need to add indexes?
	    - [ ] Have the migrations been tested?
- [ ] If this is a frontend application, can you still run the application locally using the provided script/command?
- [ ] Is this a client library, do you need to update the consumer contract tests?
- [ ] Are there any failing automated checks, and if so, have you left an explanation for reviewers?
